### PR TITLE
Fixes #3: Case Typos

### DIFF
--- a/MavSky/MavConsole.cpp
+++ b/MavSky/MavConsole.cpp
@@ -14,7 +14,7 @@
 
 #include "../EEPROM/EEPROM.h"
 
-#include <STRING.h>
+#include <string.h>
 #include "MavSky.h"
 #include "Logger.h"
 #include "DataBroker.h"       // todo needed for eeprom constants for now

--- a/MavSky/MavConsole.h
+++ b/MavSky/MavConsole.h
@@ -16,7 +16,7 @@
 #include <WProgram.h> 
 #include <GCS_MAVLink.h>
 
-#include "MavlinkData.h"
+#include "MavLinkData.h"
 
 class Logger;
   


### PR DESCRIPTION
I guess this might be developed on windows where case doesn't matter?  Compile fails on linux due to these case issues, this PR fixes those.  There might be more, I can't compile cleanly because the code doesn't support Teensy LC - it assumes too much in the led library, which is too tightly coupled to the main code.
